### PR TITLE
Make PublicKey optional in SshUserKeyCredentials

### DIFF
--- a/LibGit2Sharp/SshUserKeyCredentials.cs
+++ b/LibGit2Sharp/SshUserKeyCredentials.cs
@@ -30,11 +30,6 @@ namespace LibGit2Sharp
                 throw new InvalidOperationException("SshUserKeyCredentials contains a null Passphrase.");
             }
 
-            if (PublicKey == null)
-            {
-                throw new InvalidOperationException("SshUserKeyCredentials contains a null PublicKey.");
-            }
-
             if (PrivateKey == null)
             {
                 throw new InvalidOperationException("SshUserKeyCredentials contains a null PrivateKey.");
@@ -50,6 +45,7 @@ namespace LibGit2Sharp
 
         /// <summary>
         /// Public key file location for SSH authentication.
+        /// <para>If the public key is null, it will be derived from the private key</para>
         /// </summary>
         public string PublicKey { get; set; }
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",                  // we release out of master
     "^refs/heads/maint/v\\d+(?:\\.\\d+)?$"  // and maint/vNN branches


### PR DESCRIPTION
Libssh2 now supports deriving it from the private key file (if it contains a public key section, as it is normally the case when creating the key with ssh-keygen)