### PR TITLE
Use runtimes folder on net5 instead of lib/win32

### DIFF
--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -36,7 +36,8 @@ namespace LibGit2Sharp
             }
             else
             {
-                nativeLibraryDefaultPath = null;
+                string arch = Environment.Is64BitProcess ? "win-x64" : "win-x86";
+                nativeLibraryDefaultPath = Path.Combine(GetExecutingAssemblyDirectory(), "runtimes", arch, "native");
             }
 
             registeredFilters = new Dictionary<Filter, FilterRegistration>();

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries.UiPath" Version="0.28.9" PrivateAssets="none"/>
+    <PackageReference Include="LibGit2Sharp.NativeBinaries.UiPath" Version="0.28.8" PrivateAssets="none"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
   </ItemGroup>

--- a/NativeLibraryLoadTestApp/x64/NativeLibraryLoadTestApp.x64.csproj
+++ b/NativeLibraryLoadTestApp/x64/NativeLibraryLoadTestApp.x64.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/NativeLibraryLoadTestApp/x86/NativeLibraryLoadTestApp.x86.csproj
+++ b/NativeLibraryLoadTestApp/x86/NativeLibraryLoadTestApp.x86.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.26.9",
+  "version": "0.26.10",
   "publicReleaseRefSpec": [
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+"  
   ],


### PR DESCRIPTION
This avoids the requirement for a build target that restores the lib folder on net5
Also, reverted the nativebinaries package to the previous version