### PR TITLE
UI-41493. Use libgit2 v1.1 

### DIFF
--- a/LibGit2Sharp/Core/GitRemoteCallbacks.cs
+++ b/LibGit2Sharp/Core/GitRemoteCallbacks.cs
@@ -34,5 +34,7 @@ namespace LibGit2Sharp.Core
         internal IntPtr transport;
 
         internal IntPtr payload;
+
+        internal NativeMethods.url_resolve_callback resolve_url;
     }
 }

--- a/LibGit2Sharp/Core/NativeMethods.cs
+++ b/LibGit2Sharp/Core/NativeMethods.cs
@@ -1936,6 +1936,13 @@ namespace LibGit2Sharp.Core
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void git_transaction_free(IntPtr txn);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate int url_resolve_callback(
+            IntPtr url_resolved,
+            IntPtr url,
+            int direction,
+            IntPtr payload);
+
         [DllImport(libgit2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void git_worktree_free(git_worktree* worktree);
 

--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries.UiPath" Version="0.28.10" PrivateAssets="none"/>
+    <PackageReference Include="LibGit2Sharp.NativeBinaries.UiPath" Version="0.28.11" PrivateAssets="none"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
   </ItemGroup>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.26.11",
+  "version": "0.26.12",
   "publicReleaseRefSpec": [
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+"  
   ],


### PR DESCRIPTION
Changelist:
1. Use latest version of native binaries that includes support for `libgit2 v1.1`
2. Make `libgit2sharp` compatible with `libgit2 v1.1` by applying a patch from upstream `libgit2sharp/master`