### PR TITLE
Update GitStatusOptions to conform with the libgit2 definition UI-46471

### DIFF
--- a/LibGit2Sharp/Core/GitStatusOptions.cs
+++ b/LibGit2Sharp/Core/GitStatusOptions.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace LibGit2Sharp.Core
 {
     [StructLayout(LayoutKind.Sequential)]
-    internal class GitStatusOptions : IDisposable
+    internal unsafe sealed class GitStatusOptions : IDisposable
     {
         public uint Version = 1;
 
@@ -12,6 +12,8 @@ namespace LibGit2Sharp.Core
         public GitStatusOptionFlags Flags;
 
         public GitStrArrayManaged PathSpec;
+
+        public git_tree* baseline = default;
 
         public void Dispose()
         {

--- a/LibGit2Sharp/Core/Opaques.cs
+++ b/LibGit2Sharp/Core/Opaques.cs
@@ -2,6 +2,7 @@
 
 namespace LibGit2Sharp.Core
 {
+    internal struct git_tree {}
     internal struct git_tree_entry {}
     internal struct git_reference { }
     internal struct git_refspec {}


### PR DESCRIPTION
https://uipath.atlassian.net/browse/UI-46471

GitStatusOptions was missing the git_tree* baseline member. This is probably the occasional bug we already had with git_status_list_new, but most likely due to net5 runtime updates it now crashed everytime making it easier to diagnose and fix.