### PR TITLE
Libgit2sharp: sync git error category with libgit2

### DIFF
--- a/LibGit2Sharp/Core/GitErrorCategory.cs
+++ b/LibGit2Sharp/Core/GitErrorCategory.cs
@@ -36,6 +36,8 @@ namespace LibGit2Sharp.Core
         Filesystem,
         Patch,
         Worktree,
-        Sha1
+        Sha1,
+        Http,
+        Internal
     }
 }


### PR DESCRIPTION
add 2 missing members that are defined in libgit2\git2\errors.h