### PR TITLE
fix confusion between exception ctor(format, params args) and ctor(message, code, category)

### DIFF
--- a/LibGit2Sharp.Tests/ExceptionTests.cs
+++ b/LibGit2Sharp.Tests/ExceptionTests.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace LibGit2Sharp.Tests;
+public class ExceptionTests
+{
+    [Fact]
+    public void When_CreatingException_Given_ItHasErrorCode_Then_ErrorCodeIsSet()
+    {
+        var instance = new LibGit2SharpException("message").WithErrorCode(Core.GitErrorCode.Certificate, Core.GitErrorCategory.Ssh);
+        Assert.Equal(Core.GitErrorCategory.Ssh, instance.GitErrorCategory);
+        Assert.Equal(Core.GitErrorCode.Certificate, instance.GitErrorCode);
+    }
+}

--- a/LibGit2Sharp/Core/Ensure.cs
+++ b/LibGit2Sharp/Core/Ensure.cs
@@ -147,9 +147,10 @@ namespace LibGit2Sharp.Core
             }
 
             Func<string, GitErrorCategory, LibGit2SharpException> exceptionBuilder;
-            if (!GitErrorsToLibGit2SharpExceptions.TryGetValue((GitErrorCode)result, out exceptionBuilder))
+            var errorCode = (GitErrorCode)result;
+            if (!GitErrorsToLibGit2SharpExceptions.TryGetValue(errorCode, out exceptionBuilder))
             {
-                exceptionBuilder = (m, c) => new LibGit2SharpException(m, c);
+                exceptionBuilder = (m, c) => new LibGit2SharpException(m).WithErrorCode(errorCode, errorCategory);
             }
 
             throw exceptionBuilder(errorMessage, errorCategory);

--- a/LibGit2Sharp/Core/GitErrorCategory.cs
+++ b/LibGit2Sharp/Core/GitErrorCategory.cs
@@ -38,6 +38,7 @@ namespace LibGit2Sharp.Core
         Worktree,
         Sha1,
         Http,
-        Internal
+        Internal,
+        GraphTS
     }
 }

--- a/LibGit2Sharp/Core/Proxy.cs
+++ b/LibGit2Sharp/Core/Proxy.cs
@@ -1536,9 +1536,7 @@ namespace LibGit2Sharp.Core
             if (IntPtr.Zero == toReturn)
             {
                 throw new LibGit2SharpException("Unable to allocate {0} bytes; out of memory",
-                                                len,
-                                                GitErrorCode.Error,
-                                                GitErrorCategory.NoMemory);
+                                                len).WithErrorCode( GitErrorCode.Error, GitErrorCategory.NoMemory);
             }
 
             return toReturn;

--- a/LibGit2Sharp/GlobalSettings.cs
+++ b/LibGit2Sharp/GlobalSettings.cs
@@ -265,7 +265,7 @@ namespace LibGit2Sharp
                 // if the filter has already been registered
                 if (registeredFilters.ContainsKey(filter))
                 {
-                    throw new EntryExistsException("The filter has already been registered.", GitErrorCode.Exists, GitErrorCategory.Filter);
+                    throw new EntryExistsException("The filter has already been registered.").WithErrorCode(GitErrorCode.Exists, GitErrorCategory.Filter);
                 }
 
                 // allocate the registration object

--- a/LibGit2Sharp/LibGit2SharpException.cs
+++ b/LibGit2Sharp/LibGit2SharpException.cs
@@ -53,23 +53,25 @@ namespace LibGit2Sharp
             : base(info, context)
         { }
 
-        internal LibGit2SharpException(string message, GitErrorCode code, GitErrorCategory category) : this(message)
+        /// <summary>
+        /// The error code returned by libgit2
+        /// </summary>
+        public GitErrorCode GitErrorCode { get; private set; }
+
+        /// <summary>
+        /// The error category
+        /// </summary>
+        public  GitErrorCategory GitErrorCategory { get; private set; }
+
+        public LibGit2SharpException WithErrorCode(GitErrorCode code, GitErrorCategory category)
         {
             Data.Add("libgit2.code", (int)code);
             Data.Add("libgit2.category", (int)category);
 
             GitErrorCode = code;
             GitErrorCategory = category;
+
+            return this;
         }
-
-        /// <summary>
-        /// The error code returned by libgit2
-        /// </summary>
-        public GitErrorCode GitErrorCode { get; }
-
-        /// <summary>
-        /// The error category
-        /// </summary>
-        public  GitErrorCategory GitErrorCategory { get;  }
     }
 }


### PR DESCRIPTION
The second version was never picked and the code/categories were not set.