### PR TITLE
use libgit nativebinaries without pdbs

### DIFF
--- a/LibGit2Sharp/LibGit2Sharp.csproj
+++ b/LibGit2Sharp/LibGit2Sharp.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp.NativeBinaries.UiPath" Version="1.7.1-v3" PrivateAssets="none"/>
+    <PackageReference Include="LibGit2Sharp.NativeBinaries.UiPath" Version="1.7.1-v4" PrivateAssets="none"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
this ensures Studio will not have hard dependencies on pdb files (in the deps.json files)